### PR TITLE
Randomize item width/height to show VWP not working

### DIFF
--- a/VirtualizingWrapPanel/VirtualizingWrapPanelSamples/MainWindow.xaml
+++ b/VirtualizingWrapPanel/VirtualizingWrapPanelSamples/MainWindow.xaml
@@ -22,7 +22,8 @@
                 Loaded="Item_Loaded"
                 Unloaded="Item_Unloaded">
                 <TextBlock
-                    Width="100"
+                    Width="{Binding Width, Mode=OneTime}"
+                    Height="{Binding Height, Mode=OneTime}"
                     FontSize="20"
                     TextAlignment="Center"
                     Text="{Binding Number, Mode=OneTime}"

--- a/VirtualizingWrapPanel/VirtualizingWrapPanelSamples/TestItem.cs
+++ b/VirtualizingWrapPanel/VirtualizingWrapPanelSamples/TestItem.cs
@@ -7,6 +7,8 @@ namespace VirtualizingWrapPanelSamples
     {
         public string Group { get; }
         public int Number { get; }
+        public int Width { get; }
+        public int Height { get; }
         public Color Background { get; }
         public DateTime CurrentDateTime => DateTime.Now;
 
@@ -16,9 +18,11 @@ namespace VirtualizingWrapPanelSamples
         {
             Group = group;
             Number = number;
-            byte[] randomBytes = new byte[3];
-            random.NextBytes(randomBytes);
-            Background = Color.FromRgb(randomBytes[0], randomBytes[1], randomBytes[2]);
+            Width = random.Next(20, 200);
+            Height = random.Next(40, 80);
+            Background = Color.FromRgb(RandomByte(), RandomByte(), RandomByte());
         }
+
+        static byte RandomByte() => (byte)random.Next(0, byte.MaxValue);
     }
 }


### PR DESCRIPTION
This PR is mainly to show an issue with the `VirtualizingWrapPanel` not working for different sized items. This is an essential feature for our use case so I am hoping this can be resolved. I understand this is a non-trivial issue though, I have tried to read the 13k lines of WrapPanel reference source code to gain insight and to see if other VWP implementations could be fixed. But have yet to find a fully functional VWP.

`WrapPanel`
![image](https://user-images.githubusercontent.com/10798831/125063904-59c6d180-e0b0-11eb-9634-2f486d752741.png)

`VirtualizingWrapPanel`
![image](https://user-images.githubusercontent.com/10798831/125063937-64816680-e0b0-11eb-90fc-0e6349674f9e.png)
