### PR TITLE
添加子元素模型接口

### DIFF
--- a/src/VirtualizingWrapPanel/IVirtualizingContinueWith.cs
+++ b/src/VirtualizingWrapPanel/IVirtualizingContinueWith.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace WpfToolkit.Controls
+{
+    internal interface IVirtualizingContinueWith
+    {
+        public Action AddContinueWith { get; }
+        public Action RemoveContinueWith { get; }
+    }
+}

--- a/src/VirtualizingWrapPanel/VirtualizingPanelBase.cs
+++ b/src/VirtualizingWrapPanel/VirtualizingPanelBase.cs
@@ -321,6 +321,12 @@ namespace WpfToolkit.Controls
                     UIElement child = (UIElement)ItemContainerGenerator.GenerateNext(out bool isNewlyRealized);
                     if (isNewlyRealized || /*recycled*/!InternalChildren.Contains(child))
                     {
+                        //Action before Add
+                        if (Items?[childIndex] is IVirtualizingContinueWith continueWith)
+                        {
+                            continueWith.AddContinueWith?.Invoke();
+                        }
+
                         if (childIndex >= InternalChildren.Count)
                         {
                             AddInternalChild(child);
@@ -359,6 +365,12 @@ namespace WpfToolkit.Controls
 
                 if (itemIndex != -1 && !ItemRange.Contains(itemIndex))
                 {
+                      //Action before removal
+                    if (Items?[childIndex] is IVirtualizingContinueWith continueWith)
+                    {
+                        continueWith.RemoveContinueWith?.Invoke();
+                    }
+
                     if (VirtualizationMode == VirtualizationMode.Recycling)
                     {
                         ItemContainerGenerator.Recycle(generatorPosition, 1);


### PR DESCRIPTION
接口支持子元素在虚拟化之前发生一些操作。

实际用例：
properties Image is binding UIElement(Image) Source is ImagePath，use this interface Action clear and Reset binding imagepath

    #region IVirtualizingContinueWith
        public Action AddContinueWith { get => () => { if (this.HasImage && this.Image.IsNullOrWhiteSpace()) this.Image = this.VirtualTempImage; }; }
     
        public Action RemoveContinueWith { get => () => { if (this.HasImage && !this.Image.IsNullOrWhiteSpace()) this.Image = ""; }; }
        #endregion