### PR TITLE
Check for existence of child before trying to remove it.

### DIFF
--- a/src/VirtualizingWrapPanel/VirtualizingWrapPanel.cs
+++ b/src/VirtualizingWrapPanel/VirtualizingWrapPanel.cs
@@ -101,7 +101,12 @@ namespace WpfToolkit.Controls
                     _itemContainerManager = new ItemContainerManager(
                         ItemContainerGenerator,
                         AddInternalChild,
-                        child => RemoveInternalChildRange(InternalChildren.IndexOf(child), 1));
+                        child =>
+                        {
+                            var childIndex = InternalChildren.IndexOf(child);
+                            if(childIndex >= 0)
+                                RemoveInternalChildRange(childIndex, 1);
+                        });
                     _itemContainerManager.ItemsChanged += ItemContainerManager_ItemsChanged;
                 }
                 return _itemContainerManager;


### PR DESCRIPTION
I have an application that crashes because the code tries to remove a child that isn't there anymore.
Adding a check for the return value of IndexOf fixes the issue