### PR TITLE
Update VirtualizingWrapPanel.cs

### DIFF
--- a/src/VirtualizingWrapPanel/VirtualizingWrapPanel.cs
+++ b/src/VirtualizingWrapPanel/VirtualizingWrapPanel.cs
@@ -592,6 +592,7 @@ public class VirtualizingWrapPanel : VirtualizingPanelBase
     {
         if (itemsCount == 0)
         {
+            realizedContainers.Clear();
             startItemIndex = -1;
             endItemIndex = -1;
             startItemOffsetCrossAxis = 0;


### PR DESCRIPTION
When binding an ObservableCollection, the last item cannot be deleted.